### PR TITLE
Do not forget to install jwt

### DIFF
--- a/aws/ec2/install
+++ b/aws/ec2/install
@@ -24,6 +24,9 @@ rvm use     "$RUBY" --default
 # Install Bundler
 gem install bundler
 
+# Install jwt
+gem install jwt
+
 # Download Utterson
 git clone https://github.com/jekyll/Utterson.git Utterson
 


### PR DESCRIPTION
`jwt` is required for requesting tokens from GitHub, and nothing works without it.

It should be installed by the install script.