### PR TITLE
Report failed builds

### DIFF
--- a/aws/sqs/process
+++ b/aws/sqs/process
@@ -3,6 +3,14 @@
 
 # Builds a PR based on a message received from SQS
 
+function reportFailure {
+  if [[ $? != 0 ]]; then
+    echo "Build Failure"
+    URL=$URL BRANCH=$HEAD HEAD=$HEAD_SHA ./github/checks/fail
+    exit
+  fi
+}
+
 JSON_RESPONSE=$(aws sqs receive-message --queue-url "$QUEUE_URL" --message-attribute-names All)
 
 if [[ -z $JSON_RESPONSE ]]; then
@@ -31,9 +39,9 @@ fi
 # Before each build, we lock the message for 20 minutes + 10 seconds
 #   (our maximum allowed build time + a grace period)
 aws sqs change-message-visibility --receipt-handle "$RECEIPT_HANDLE" --queue-url "$QUEUE_URL" --visibility-timeout 1210
-REF="$BASE" ./bench
+REF="$BASE" ./bench || reportFailure
 aws sqs change-message-visibility --receipt-handle "$RECEIPT_HANDLE" --queue-url "$QUEUE_URL" --visibility-timeout 1210
- PR="$PR"   ./bench
+ PR="$PR"   ./bench || reportFailure
 
 # Now that we are done building, we only need to lock the message for long
 # enough to generate our report. If something fails, we want the message to

--- a/bench
+++ b/bench
@@ -2,6 +2,15 @@
 set -e
 ulimit -t 1200
 
+function checkFailedBuild {
+  if [[ $? != 0 ]]; then
+    echo "Build failed"
+    exit 1
+  fi
+}
+
+trap checkFailedBuild Exit
+
 export BUNDLE_GEMFILE="$(pwd)/Gemfile"
 bundle update
 

--- a/github/checks/fail
+++ b/github/checks/fail
@@ -1,0 +1,29 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "json"
+require "net/http"
+require "uri"
+require "date"
+
+token = File.expand_path("../token", __dir__)
+date = Time.now.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+json = JSON(
+  :name         => "Performance Check",
+  :status       => "completed",
+  :conclusion   => "failure",
+  :completed_at => date,
+  :head_branch  => ENV["BRANCH"],
+  :head_sha     => ENV["HEAD"]
+)
+
+uri = URI("#{ENV["URL"]}/check-runs")
+req = Net::HTTP::Post.new(uri)
+req["Authorization"] = "token #{`#{token}`}"
+req["Accept"] = "application/vnd.github.antiope-preview+json"
+req.body = json
+
+http = Net::HTTP.new(uri.hostname, uri.port)
+http.use_ssl = (uri.scheme == "https")
+http.request(req)


### PR DESCRIPTION
If a build fails, we should report that to GitHub, instead of trying to continue and reporting a possibly very inaccurate build time.

Fixes #14