### PR TITLE
Flush SASS cache before running bench

### DIFF
--- a/bench
+++ b/bench
@@ -48,6 +48,11 @@ fi
 mkdir -p "$TMPDIR/source"
 mkdir -p "$TMPDIR/destination"
 
+# Flush SASS cache
+if [[ -d "$(pwd)/.sass-cache" ]]; then
+	rm -rf "$(pwd)/.sass-cache"
+fi
+
 for SITE in $(cat "site-list"); do
 	SOURCE="$TMPDIR/source/$($MD5 <<< $SITE)"
 	DESTINATION=${SOURCE/source/destination}


### PR DESCRIPTION
We don't need to flush the cache before each _build_, but we should flush it once before each run so that each run of `./bench` is isolated.