### PR TITLE
Shutdown if no other users are logged in

### DIFF
--- a/aws/ec2/boot
+++ b/aws/ec2/boot
@@ -10,9 +10,9 @@ checkloop() {
 		echo "Checking for more messages."
 	done
 	local USERS=$( who | wc -l )
-	if (( USERS < 2 )); then
+	if (( USERS = 0 )); then
 		wall "Shutting down."
-#		shutdown -h now
+		shutdown -h now
 	fi
 }
 


### PR DESCRIPTION
If there are no users logged in, and no more messages in the queue, EC2 should shutdown and wait for the next webhook.