### PR TITLE
Strip whitespace from token

### DIFF
--- a/github/checks/complete
+++ b/github/checks/complete
@@ -27,7 +27,7 @@ json = JSON(
 
 uri = URI("#{ENV["URL"]}/check-runs")
 req = Net::HTTP::Post.new(uri)
-req["Authorization"] = "token #{`#{token}`}"
+req["Authorization"] = "token #{`#{token}`.chomp}"
 req["Accept"] = "application/vnd.github.antiope-preview+json"
 req.body = json
 

--- a/github/checks/fail
+++ b/github/checks/fail
@@ -20,7 +20,7 @@ json = JSON(
 
 uri = URI("#{ENV["URL"]}/check-runs")
 req = Net::HTTP::Post.new(uri)
-req["Authorization"] = "token #{`#{token}`}"
+req["Authorization"] = "token #{`#{token}`.chomp}"
 req["Accept"] = "application/vnd.github.antiope-preview+json"
 req.body = json
 

--- a/github/checks/start
+++ b/github/checks/start
@@ -20,7 +20,7 @@ json = JSON(
 
 uri = URI("#{ENV["URL"]}/check-runs")
 req = Net::HTTP::Post.new(uri)
-req["Authorization"] = "token #{`#{token}`}"
+req["Authorization"] = "token #{`#{token}`.chomp}"
 req["Accept"] = "application/vnd.github.antiope-preview+json"
 req.body = json
 


### PR DESCRIPTION
If there is a trailing newline in the `Authorization` header, nothing works!
Fixes #29