### PR TITLE
Delete message when build fails

### DIFF
--- a/aws/sqs/process
+++ b/aws/sqs/process
@@ -7,6 +7,7 @@ function reportFailure {
   if [[ $? != 0 ]]; then
     echo "Build Failure"
     URL=$URL BRANCH=$HEAD HEAD=$HEAD_SHA ./github/checks/fail
+    aws sqs delete-message --receipt-handle "$RECEIPT_HANDLE" --queue-url "$QUEUE_URL"
     exit
   fi
 }


### PR DESCRIPTION
Because we are using a FIFO queue (which I am beginning to think is not the best idea), a bad message at the front of the queue will forever block anything else from being built.

If a build fails, we need to report the failure to GitHub and kick that message out of the queue so we can move on with life.