### PR TITLE
Allow specify PR *and* REF

### DIFF
--- a/bench
+++ b/bench
@@ -20,10 +20,10 @@ if [[ ! -s $RESULTS ]]; then
 	echo "Jekyll version, user time in seconds, site" > $RESULTS
 fi
 
-if [[ -n $REF ]]; then
-	VERSION=$REF
-elif [[ -n $PR ]]; then
+if [[ -n $PR ]]; then
 	VERSION="#$PR"
+elif [[ -n $REF ]]; then
+	VERSION=$REF
 else
 	VERSION="master"
 fi


### PR DESCRIPTION
It would be nice to specify a _specific_ commit to build with, but still label the PR in `results.csv`.

If both `PR` and `REF` are specified, `REF` will be used to checkout a specific Jekyll commit, and `PR` will be used to label the entries in `results.csv`.