### PR TITLE
Add regression testing

### DIFF
--- a/bench
+++ b/bench
@@ -47,12 +47,16 @@ if [[ -d "$(pwd)/.sass-cache" ]]; then
 	rm -rf "$(pwd)/.sass-cache"
 fi
 
+if [[ -z $DESTINATION_DIR ]]; then
+	DESTINATION_DIR="destination"
+fi
+
 for SITE in $(cat "site-list"); do
 	echo ""
 	echo "Sampling: $SITE"
 	echo ""
 	SOURCE="$TMPDIR/source/${SITE##*/}"
-	DESTINATION=${SOURCE/source/destination}
+	DESTINATION=${SOURCE/source/$DESTINATION_DIR}
 	if [[ ! -d $SOURCE ]]; then
 		git clone --recurse-submodules -q "$SITE" "$SOURCE"
 	fi

--- a/regression
+++ b/regression
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# After running `./bench` twice on different versions of Jekyll, this command
+# will diff the different builds of each site and complain if they are not
+# identical. This will help catch unintentional changes in Jekyll's behavior.
+
+set -e
+ulimit -t 1200
+
+function checkFailedBuild {
+  if [[ $? != 0 ]]; then
+    echo "Build failed"
+    exit 1
+  fi
+}
+
+trap checkFailedBuild Exit
+
+# Create tmp/ directory
+TMPDIR="$(pwd)/sites"
+if [[ -d $TMPDIR ]]; then
+	rm -rf "$TMPDIR"
+fi
+
+SUCCESS=0
+
+for SITE in $(cat "site-list"); do
+	echo ""
+	echo "Diffing: $SITE"
+	echo ""
+	SOURCE="$TMPDIR/$OLD/${SITE##*/}"
+	DESTINATION=${SOURCE/$OLD/$NEW}
+	diff -r $SOURCE $DESTINATION
+	if (( $? != 0 )); then
+		SUCCESS=1
+	fi
+done
+
+exit $SUCCESS


### PR DESCRIPTION
This provides a way of performing regression testing on generated sites.

If the base branch is built with `DESTINATION_DIR="old" ./bench` and the head branch is built with `DESTINATION_DIR="new" ./bench`, then one can run `OLD="old" NEW="new" ./regression` to see a diff of the two builds. If there are any differences, `regression` will exit with a non-zero status.

This is not yet automated. That might be a bit more work.