### PR TITLE
Log memory and file system access

### DIFF
--- a/bench
+++ b/bench
@@ -17,7 +17,7 @@ bundle update
 NUMBER_OF_RUNS=3
 RESULTS="$(pwd)/results.csv"
 if [[ ! -s $RESULTS ]]; then
-	echo "Jekyll version, user time in seconds, site" > $RESULTS
+	echo "Jekyll version, user time in seconds, site, Maximum memory, Number of file writes, Number of file reads" > $RESULTS
 fi
 
 if [[ -n $PR ]]; then
@@ -65,7 +65,7 @@ for SITE in $(cat "site-list"); do
 		git clone --recurse-submodules -q "$SITE" "$SOURCE"
 	fi
 	for ((i=0; i<NUMBER_OF_RUNS; ++i)); do
-		"$TIME" -ao "$RESULTS" -f"$VERSION,%U,$SITE" \
+		"$TIME" -ao "$RESULTS" -f"$VERSION,%U,$SITE,%M,%O,%I" \
 			bundle exec jekyll build -s "$SOURCE" -d "$DESTINATION" --trace
 	done
 


### PR DESCRIPTION
We would really like to know the impact that different caching strategies have on the memory footprint of Jekyll.

This change will log the maximum memory used during each build so that we can see if we do something that radically increases the amount of memory required for Jekyll to build sites.