### PR TITLE
Change separator between sites

### DIFF
--- a/bench
+++ b/bench
@@ -55,9 +55,9 @@ if [[ -n $FLAMEGRAPH ]]; then
 fi
 
 for SITE in $(cat "site-list"); do
-	echo ""
-	echo "Sampling: $SITE"
-	echo ""
+	echo "
+________________________________________________________________________________
+          Sampling: $SITE"
 	SOURCE="$TMPDIR/source/${SITE##*/}"
 	DESTINATION=${SOURCE/source/destination}
 	SVG_PATH="docs/$REF/${SITE##*/}"


### PR DESCRIPTION
Followup to #44, this uses a nicer separator between sites:

```text
                    done in 4.794 seconds.
 Auto-regeneration: disabled. Use --watch to enable.

________________________________________________________________________________
          Sampling: https://github.com/grantmakers/grantmakers.github.io
Configuration file: /Users/hawks/GitHub/Utterson/sites/source/grantmakers.github.io/_config.yml
            Source: /Users/hawks/GitHub/Utterson/sites/source/grantmakers.github.io
       Destination: /Users/hawks/GitHub/Utterson/sites/destination/grantmakers.github.io
 Incremental build: disabled. Enable with --incremental
      Generating... 
```

(To my eyes) this makes it just a little easier to see where one site ends and the next begins.